### PR TITLE
Lint markdown files for style

### DIFF
--- a/docs/jekyll-guide.md
+++ b/docs/jekyll-guide.md
@@ -235,7 +235,8 @@ exclude:
 
 ### Environment-Specific Configurations
 
-> **Note**: For versioned documentation, the main `_config.yml` is dynamically modified by default. See the [Versioning Guide](versioning-guide.md) for details.
+> **Note**: For versioned documentation, the main `_config.yml` is dynamically modified by default. See the
+> [Versioning Guide](versioning-guide.md) for details.
 
 #### Development Configuration
 

--- a/docs/versioning-guide.md
+++ b/docs/versioning-guide.md
@@ -8,7 +8,8 @@ parent: "📖 Examples & Guides"
 
 # 🔀 Documentation Versioning Guide
 
-Complete guide to implementing versioned documentation with automatic Doxygen and Jekyll integration using the enhanced `docs.yml` workflow.
+Complete guide to implementing versioned documentation with automatic Doxygen and Jekyll integration using the
+enhanced `docs.yml` workflow.
 
 ## 📋 Table of Contents
 
@@ -117,7 +118,8 @@ No custom templates are needed - the workflow handles everything automatically.
 
 **Navigation for Versioned Docs:**
 
-Just the Docs uses **front matter navigation** (not `_data/navigation.yml`), so versioned navigation is handled automatically through page front matter:
+Just the Docs uses **front matter navigation** (not `_data/navigation.yml`), so versioned navigation is handled
+automatically through page front matter:
 
 ```yaml
 ---


### PR DESCRIPTION
Fix markdown linting line length violations to resolve CI failures.

This PR addresses three specific line length violations in `docs/jekyll-guide.md` and `docs/versioning-guide.md` by splitting long lines, ensuring all markdown files adhere to the 120-character line limit.
