### PR TITLE
Integrate doxygen api links into nav

### DIFF
--- a/_config/_config.yml
+++ b/_config/_config.yml
@@ -99,6 +99,8 @@ aux_links:
     - "https://github.com/n3b3x/hf-general-ci-tools/issues"
   "⭐ Star on GitHub":
     - "https://github.com/n3b3x/hf-general-ci-tools/stargazers"
+  "📖 API Reference":
+    - "/hf-general-ci-tools/doxs/index.html"
 
 # Footer customization
 footer_content: >
@@ -122,6 +124,8 @@ just_the_docs:
       url: https://github.com/n3b3x/hf-general-ci-tools
     - title: "🐛 Issues"
       url: https://github.com/n3b3x/hf-general-ci-tools/issues
+    - title: "📖 API Reference"
+      url: /hf-general-ci-tools/doxs/index.html
 
   # Custom head content
   head_custom: _includes/head_custom.html


### PR DESCRIPTION
Add API Reference links to auxiliary and navigation menus to properly link Doxygen documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf612d69-e1d8-4e23-9aa4-6820316ada91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf612d69-e1d8-4e23-9aa4-6820316ada91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

