### PR TITLE
Check doxygen config file detection

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,6 +26,10 @@ jobs:
       # Versioning Configuration (Always Enabled)
       # =============================================================================
       deployment_branch: 'gh-pages'  # Required for versioned documentation
+      # =============================================================================
+      # Doxygen Configuration
+      # =============================================================================
+      doxygen_config: "_config/Doxyfile"
 
       # =============================================================================
       # Jekyll Configuration


### PR DESCRIPTION
Pass `doxygen_config` to the documentation workflow to enable Doxygen detection.

The `doxygen_config` input was not being forwarded to the `docs.yml` reusable workflow, causing it to fall back to the default `Doxyfile` path and fail to detect the custom Doxyfile.